### PR TITLE
Hack for varying by Authorization headers

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -41,6 +41,14 @@ type Cache interface {
 
 // cacheKey returns the cache key for req.
 func cacheKey(req *http.Request) string {
+
+	// Ideally we'd compute the cache key by taking into account the Vary headers.
+	// Ugly hack for now -- add the authorization header to the cache key.
+	auth := req.Header.Get("Authorization")
+	if auth != "" {
+		return auth + "_" + req.URL.String()
+	}
+
 	return req.URL.String()
 }
 


### PR DESCRIPTION
What we'd really like to do is use the contents of the Vary header to determine the cache key. That would require a substantial refactoring of this library. For (one) particular use case this hack does what we need.