### PR TITLE
Fix caching of non-GET requests

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -41,7 +41,7 @@ type Cache interface {
 // cacheKey returns the cache key for req.
 func cacheKey(req *http.Request) string {
 	var key string
-	if req.Method != http.MethodGet {
+	if req.Method == http.MethodGet {
 		key = req.URL.String()
 	} else {
 		key = req.Method + " " + req.URL.String()


### PR DESCRIPTION
I had accidentally swapped the case of during the merge.  The effect would be that non-GET requests would have mapped to each other.

This apparently isn't covered by tests although we aren't running in CI anyway.  I'm reluctant to add a test for this and to diverge more from master but could be convinced otherwise.