### PR TITLE
Do not purge httpcache when transport or backend fails.

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -263,7 +263,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		} else if (err != nil || resp.StatusCode >= 500) &&
 			req.Method == "GET" && keepOnError(req.Header) {
 			// In case of transport or backend server failure and keep-on-error activated, keep the cache
-			return nil, err
+			return resp, err
 		} else {
 			if err != nil || resp.StatusCode != http.StatusOK {
 				t.Cache.Delete(cacheKey)

--- a/httpcache.go
+++ b/httpcache.go
@@ -261,7 +261,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			cachedResp.StatusCode = http.StatusOK
 			return cachedResp, nil
 		} else if (err != nil || resp.StatusCode >= 500) &&
-			req.Method == "GET" && keepOnError(req.Header) {
+			req.Method == "GET" && keepCacheOnError(req.Header) {
 			// In case of transport or backend server failure and keep-on-error activated, keep the cache
 			return resp, err
 		} else {
@@ -444,7 +444,7 @@ func getFreshness(respHeaders, reqHeaders http.Header) (freshness int) {
 	return stale
 }
 
-func keepOnError(reqHeaders http.Header) bool {
+func keepCacheOnError(reqHeaders http.Header) bool {
 	reqCacheControl := parseCacheControl(reqHeaders)
 	val, ok := reqCacheControl["keep-on-error"]
 	return ok && val == "true"

--- a/httpcache.go
+++ b/httpcache.go
@@ -260,7 +260,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			cachedResp.Status = fmt.Sprintf("%d %s", http.StatusOK, http.StatusText(http.StatusOK))
 			cachedResp.StatusCode = http.StatusOK
 			return cachedResp, nil
-		} else if (err != nil || (cachedResp != nil && resp.StatusCode >= 500)) &&
+		} else if (err != nil || resp.StatusCode >= 500) &&
 			req.Method == "GET" && keepOnError(req.Header) {
 			// In case of transport or backend server failure and keep-on-error activated, keep the cache
 			return nil, err


### PR DESCRIPTION
## Description

In streamer we are often seeing issues where if 1 varnish node is unavailable, we end up evicting good data from the local cache and thus leads to full data transfer on retry.

Instead we want to introduce a new cache directory `keep-on-error` which instructs http cache then when backend or transport fails, do not purge current entry. It still returns underlying error to main flow.

`stale-if-error` can still override `keep-on-error` directive as it returns cached entry.